### PR TITLE
Update dependencies

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6,16 +6,19 @@ var markdown2confluence = require('markdown2confluence');
 var fsp = require('fs-promise');
 var fs = require('fs');
 var path = require('path');
-var winston = require('winston');
+
+var _require = require('winston'),
+    createLogger = _require.createLogger,
+    format = _require.format,
+    transports = _require.transports;
 
 // A preffer to use this instead console.log
-var logger = new winston.Logger({
-  transports: [new winston.transports.Console({
-    handleExceptions: true,
-    json: false,
-    colorize: true
-  })],
-  exitOnError: true
+
+
+var logger = createLogger({
+  transports: [new transports.Console()],
+  exitOnError: true,
+  format: format.cli()
 });
 var prompts = [];
 var user = process.env.MD2CUSER;
@@ -69,6 +72,8 @@ inquirer.prompt(prompts).then(function (_answers) {
   var _loop = function _loop(i) {
     var pageData = config.pages[i];
 
+    logger.debug('Starting to render "' + pageData.mdfile + '"');
+
     // 1. Get the markdown file content
     fsp.readFile(pageData.mdfile, { encoding: 'utf8' }).then(function (fileData) {
       // 2. Transform the content to Markdown Wiki
@@ -101,7 +106,6 @@ inquirer.prompt(prompts).then(function (_answers) {
         },
         json: true // Automatically stringifies the body to JSON
       })
-
       // 4. Get current data of the confluence page
       .then(function (data) {
         newContent = data;
@@ -150,7 +154,7 @@ inquirer.prompt(prompts).then(function (_answers) {
       })
 
       // everything is saved
-      .then(function () /* data */{
+      .then(function () {
         logger.info('"' + currentPage.title + '" saved in confluence.');
       });
     }).catch(function (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,18 +4,13 @@ const markdown2confluence = require('markdown2confluence');
 const fsp = require('fs-promise');
 const fs = require('fs');
 const path = require('path');
-const winston = require('winston');
+const { createLogger, format, transports } = require('winston');
 
 // A preffer to use this instead console.log
-const logger = new winston.Logger({
-  transports: [
-    new winston.transports.Console({
-      handleExceptions: true,
-      json: false,
-      colorize: true,
-    }),
-  ],
+const logger = createLogger({
+  transports: [new transports.Console()],
   exitOnError: true,
+  format: format.cli(),
 });
 const prompts = [];
 const user = process.env.MD2CUSER;
@@ -68,8 +63,11 @@ inquirer.prompt(prompts).then((_answers) => {
   for (let i = 0; i < config.pages.length; i += 1) {
     const pageData = config.pages[i];
 
+    logger.debug(`Starting to render "${pageData.mdfile}"`);
+
     // 1. Get the markdown file content
-    fsp.readFile(pageData.mdfile, { encoding: 'utf8' })
+    fsp
+      .readFile(pageData.mdfile, { encoding: 'utf8' })
       .then((fileData) => {
         // 2. Transform the content to Markdown Wiki
         let mdWikiData = markdown2confluence(fileData);
@@ -84,75 +82,76 @@ inquirer.prompt(prompts).then((_answers) => {
         }
 
         // 3. Transform the Markdown Wiki to Storage (confluence scripting)
-        return rp({
-          method: 'POST',
-          uri: `${config.baseUrl}/contentbody/convert/storage`,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: {
-            value: mdWikiData,
-            representation: 'wiki',
-          },
-          auth: {
-            user: answers.user,
-            pass: answers.pass,
-            sendImmediately: true,
-          },
-          json: true, // Automatically stringifies the body to JSON
-        })
-
-        // 4. Get current data of the confluence page
-        .then((data) => {
-          newContent = data;
-
-          return rp({
-            method: 'GET',
-            uri: `${config.baseUrl}/content/${pageData.pageid}`,
-            body: {
-              some: 'payload',
-            },
-            auth: {
-              user: answers.user,
-              pass: answers.pass,
-              sendImmediately: true,
-            },
-            json: true, // Automatically stringifies the body to JSON
-          });
-        })
-
-        // 5. Update the page in confluence
-        .then((data) => {
-          currentPage = data;
-          currentPage.title = pageData.title;
-          currentPage.body = {
-            storage: {
-              value: newContent.value,
-              representation: 'storage',
-            },
-          };
-          currentPage.version.number = parseInt(currentPage.version.number, 10) + 1;
-
-          return rp({
-            method: 'PUT',
-            uri: `${config.baseUrl}/content/${pageData.pageid}`,
+        return (
+          rp({
+            method: 'POST',
+            uri: `${config.baseUrl}/contentbody/convert/storage`,
             headers: {
               'Content-Type': 'application/json',
             },
-            body: currentPage,
+            body: {
+              value: mdWikiData,
+              representation: 'wiki',
+            },
             auth: {
               user: answers.user,
               pass: answers.pass,
               sendImmediately: true,
             },
             json: true, // Automatically stringifies the body to JSON
-          });
-        })
+          })
+            // 4. Get current data of the confluence page
+            .then((data) => {
+              newContent = data;
 
-        // everything is saved
-        .then((/* data */) => {
-          logger.info(`"${currentPage.title}" saved in confluence.`);
-        });
+              return rp({
+                method: 'GET',
+                uri: `${config.baseUrl}/content/${pageData.pageid}`,
+                body: {
+                  some: 'payload',
+                },
+                auth: {
+                  user: answers.user,
+                  pass: answers.pass,
+                  sendImmediately: true,
+                },
+                json: true, // Automatically stringifies the body to JSON
+              });
+            })
+
+            // 5. Update the page in confluence
+            .then((data) => {
+              currentPage = data;
+              currentPage.title = pageData.title;
+              currentPage.body = {
+                storage: {
+                  value: newContent.value,
+                  representation: 'storage',
+                },
+              };
+              currentPage.version.number = parseInt(currentPage.version.number, 10) + 1;
+
+              return rp({
+                method: 'PUT',
+                uri: `${config.baseUrl}/content/${pageData.pageid}`,
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: currentPage,
+                auth: {
+                  user: answers.user,
+                  pass: answers.pass,
+                  sendImmediately: true,
+                },
+                json: true, // Automatically stringifies the body to JSON
+              });
+            })
+
+            // everything is saved
+            .then(() => {
+              logger.info(`"${currentPage.title}" saved in confluence.`);
+            })
+        );
       })
       .catch((err) => {
         logger.error(err);

--- a/package.json
+++ b/package.json
@@ -38,21 +38,21 @@
   },
   "homepage": "https://github.com/jormar/md2confluence#readme",
   "devDependencies": {
-    "babel": "6.5.2",
-    "babel-cli": "6.18.0",
-    "babel-preset-es2015": "6.18.0",
-    "eslint": "3.9.0",
-    "eslint-config-airbnb": "12.0.0",
-    "eslint-plugin-import": "1.16.0",
-    "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-react": "6.4.1"
+    "babel": "6.23.0",
+    "babel-cli": "6.26.0",
+    "babel-preset-es2015": "6.24.1",
+    "eslint": "5.12.1",
+    "eslint-config-airbnb": "17.1.0",
+    "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-react": "7.12.4"
   },
   "dependencies": {
-    "fs-promise": "0.5.0",
-    "inquirer": "1.2.2",
-    "markdown2confluence": "1.1.7",
-    "request": "2.76.0",
-    "request-promise": "4.1.1",
-    "winston": "2.2.0"
+    "fs-promise": "2.0.3",
+    "inquirer": "6.2.1",
+    "markdown2confluence": "1.3.0",
+    "request": "2.88.0",
+    "request-promise": "4.2.2",
+    "winston": "3.1.0"
   }
 }


### PR DESCRIPTION
update all dependencies and upgrade winston logger.

This PR is necessary because the latest version of markdown2confluence contains bugfixes for image transformation.